### PR TITLE
Update licence to MIT

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "carehare"
 version = "0.0.0"
 description = "asyncio RabbitMQ client"
 authors = ["Adam Hooper <adam@adamhooper.com>"]
-license = "BSD"
+license = "MIT"
 readme = "README.rst"
 
 [tool.poetry.dependencies]


### PR DESCRIPTION
Update `pyproject.toml` to reference the MIT licence, stated as the correct licence for this repository.

Close #10 